### PR TITLE
Actually wait for the deputy to die, consistently

### DIFF
--- a/bot2-procman/python/src/bot_procman/sheriff_gtk/sheriff_gtk.py
+++ b/bot2-procman/python/src/bot_procman/sheriff_gtk/sheriff_gtk.py
@@ -276,7 +276,7 @@ class SheriffGtk(object):
                 self.spawned_deputy.terminate()
             except AttributeError: # python 2.4, 2.5 don't have Popen.terminate()
                 os.kill(self.spawned_deputy.pid, signal.SIGTERM)
-                self.spawned_deputy.wait()
+            self.spawned_deputy.wait()
         self.spawned_deputy = None
 
     def _check_spawned_deputy(self):


### PR DESCRIPTION
Noticed that the sheriff exits without waiting for children to die, discovered this - `subprocess.Popen.terminate` does that exact same `os.kill` but doesn't `wait`; no reason for the code to be different across those two paths, and it seems pretty clearly wrong not to be waiting (it certainly causes trouble when killing and restarting and entire set of jobs at once, you have to watch for any slow jobs to _really_ terminate.)
